### PR TITLE
Add shift assignments

### DIFF
--- a/api/db/migrations/20220614001443_create_shift_assignments/migration.sql
+++ b/api/db/migrations/20220614001443_create_shift_assignments/migration.sql
@@ -1,0 +1,35 @@
+-- CreateTable
+CREATE TABLE "ShiftAssignment" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "workerId" INTEGER NOT NULL,
+    "shiftId" INTEGER NOT NULL,
+    CONSTRAINT "ShiftAssignment_workerId_fkey" FOREIGN KEY ("workerId") REFERENCES "Worker" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "ShiftAssignment_shiftId_fkey" FOREIGN KEY ("shiftId") REFERENCES "Shift" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+-- RedefineTables
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_Worker" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "firstName" TEXT NOT NULL,
+    "lastName" TEXT NOT NULL,
+    "phone" TEXT,
+    "email" TEXT,
+    "addressId" INTEGER,
+    "jobType" TEXT,
+    "employmentStatus" TEXT NOT NULL DEFAULT 'active',
+    "shiftId" INTEGER,
+    CONSTRAINT "Worker_addressId_fkey" FOREIGN KEY ("addressId") REFERENCES "Address" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+INSERT INTO "new_Worker" ("addressId", "email", "employmentStatus", "firstName", "id", "jobType", "lastName", "phone", "shiftId") SELECT "addressId", "email", "employmentStatus", "firstName", "id", "jobType", "lastName", "phone", "shiftId" FROM "Worker";
+DROP TABLE "Worker";
+ALTER TABLE "new_Worker" RENAME TO "Worker";
+CREATE UNIQUE INDEX "Worker_addressId_key" ON "Worker"("addressId");
+PRAGMA foreign_key_check;
+PRAGMA foreign_keys=ON;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ShiftAssignment_workerId_shiftId_key" ON "ShiftAssignment"("workerId", "shiftId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ShiftAssignment_workerId_key" ON "ShiftAssignment"("workerId");

--- a/api/db/migrations/20220614003321_drop_shift_id/migration.sql
+++ b/api/db/migrations/20220614003321_drop_shift_id/migration.sql
@@ -1,0 +1,28 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `shiftId` on the `Worker` table. All the data in the column will be lost.
+
+*/
+-- DropIndex
+DROP INDEX "ShiftAssignment_workerId_key";
+
+-- RedefineTables
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_Worker" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "firstName" TEXT NOT NULL,
+    "lastName" TEXT NOT NULL,
+    "phone" TEXT,
+    "email" TEXT,
+    "addressId" INTEGER,
+    "jobType" TEXT,
+    "employmentStatus" TEXT NOT NULL DEFAULT 'active',
+    CONSTRAINT "Worker_addressId_fkey" FOREIGN KEY ("addressId") REFERENCES "Address" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+INSERT INTO "new_Worker" ("addressId", "email", "employmentStatus", "firstName", "id", "jobType", "lastName", "phone") SELECT "addressId", "email", "employmentStatus", "firstName", "id", "jobType", "lastName", "phone" FROM "Worker";
+DROP TABLE "Worker";
+ALTER TABLE "new_Worker" RENAME TO "Worker";
+CREATE UNIQUE INDEX "Worker_addressId_key" ON "Worker"("addressId");
+PRAGMA foreign_key_check;
+PRAGMA foreign_keys=ON;

--- a/api/db/schema.prisma
+++ b/api/db/schema.prisma
@@ -28,8 +28,7 @@ model Worker {
   address          Address? @relation(fields: [addressId], references: [id])
   jobType          String? //think about making flexible
   employmentStatus String   @default("active") //change to bool, int maybe later
-  shiftId          Int?
-  shift            Shift?   @relation(fields: [shiftId], references: [id])
+  shifts           ShiftAssignment[]
 }
 
 model Worksite {
@@ -51,7 +50,17 @@ model Shift {
   name       String
   locationId Int
   location   Location @relation(fields: [locationId], references: [id])
-  workers    Worker[]
+  workers    ShiftAssignment[]
+}
+
+model ShiftAssignment {
+  id         Int     @id @default(autoincrement())
+  workerId   Int
+  worker     Worker  @relation(fields: [workerId], references: [id])
+  shiftId    Int
+  shift      Shift   @relation(fields: [shiftId], references: [id])
+
+  @@unique([workerId, shiftId])
 }
 
 model Address {

--- a/api/src/graphql/shiftAssignments.sdl.ts
+++ b/api/src/graphql/shiftAssignments.sdl.ts
@@ -1,0 +1,34 @@
+export const schema = gql`
+  type ShiftAssignment {
+    id: Int!
+    workerId: Int!
+    worker: Worker!
+    shiftId: Int!
+    shift: Shift!
+  }
+
+  type Query {
+    shiftAssignments: [ShiftAssignment!]! @requireAuth
+    shiftAssignment(id: Int!): ShiftAssignment @requireAuth
+  }
+
+  input CreateShiftAssignmentInput {
+    workerId: Int!
+    shiftId: Int!
+  }
+
+  input UpdateShiftAssignmentInput {
+    workerId: Int
+    shiftId: Int
+  }
+
+  type Mutation {
+    createShiftAssignment(input: CreateShiftAssignmentInput!): ShiftAssignment!
+      @requireAuth
+    updateShiftAssignment(
+      id: Int!
+      input: UpdateShiftAssignmentInput!
+    ): ShiftAssignment! @requireAuth
+    deleteShiftAssignment(id: Int!): ShiftAssignment! @requireAuth
+  }
+`

--- a/api/src/graphql/shifts.sdl.ts
+++ b/api/src/graphql/shifts.sdl.ts
@@ -4,6 +4,7 @@ export const schema = gql`
     name: String!
     locationId: Int!
     location: Location!
+    workers: [ShiftAssignment]!
   }
 
   type Query {

--- a/api/src/graphql/workers.sdl.ts
+++ b/api/src/graphql/workers.sdl.ts
@@ -9,6 +9,7 @@ export const schema = gql`
     address: Address
     jobType: String
     employmentStatus: String!
+    shifts: [ShiftAssignment]!
   }
 
   type Query {

--- a/api/src/services/shiftAssignments/shiftAssignments.scenarios.ts
+++ b/api/src/services/shiftAssignments/shiftAssignments.scenarios.ts
@@ -1,0 +1,40 @@
+import type { Prisma } from '@prisma/client'
+
+export const standard = defineScenario<Prisma.ShiftAssignmentCreateArgs>({
+  shiftAssignment: {
+    one: {
+      data: {
+        worker: { create: { firstName: 'String', lastName: 'String' } },
+        shift: {
+          create: {
+            name: 'String',
+            location: {
+              create: {
+                name: 'String',
+                worksite: { create: { name: 'String' } },
+              },
+            },
+          },
+        },
+      },
+    },
+    two: {
+      data: {
+        worker: { create: { firstName: 'String', lastName: 'String' } },
+        shift: {
+          create: {
+            name: 'String',
+            location: {
+              create: {
+                name: 'String',
+                worksite: { create: { name: 'String' } },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+})
+
+export type StandardScenario = typeof standard

--- a/api/src/services/shiftAssignments/shiftAssignments.test.ts
+++ b/api/src/services/shiftAssignments/shiftAssignments.test.ts
@@ -1,0 +1,71 @@
+import {
+  shiftAssignments,
+  shiftAssignment,
+  createShiftAssignment,
+  updateShiftAssignment,
+  deleteShiftAssignment,
+} from './shiftAssignments'
+import type { StandardScenario } from './shiftAssignments.scenarios'
+
+// Generated boilerplate tests do not account for all circumstances
+// and can fail without adjustments, e.g. Float and DateTime types.
+//           Please refer to the RedwoodJS Testing Docs:
+//       https://redwoodjs.com/docs/testing#testing-services
+// https://redwoodjs.com/docs/testing#jest-expect-type-considerations
+
+describe('shiftAssignments', () => {
+  scenario(
+    'returns all shiftAssignments',
+    async (scenario: StandardScenario) => {
+      const result = await shiftAssignments()
+
+      expect(result.length).toEqual(
+        Object.keys(scenario.shiftAssignment).length
+      )
+    }
+  )
+
+  scenario(
+    'returns a single shiftAssignment',
+    async (scenario: StandardScenario) => {
+      const result = await shiftAssignment({
+        id: scenario.shiftAssignment.one.id,
+      })
+
+      expect(result).toEqual(scenario.shiftAssignment.one)
+    }
+  )
+
+  scenario('creates a shiftAssignment', async (scenario: StandardScenario) => {
+    const result = await createShiftAssignment({
+      input: {
+        workerId: scenario.shiftAssignment.two.workerId,
+        shiftId: scenario.shiftAssignment.two.shiftId,
+      },
+    })
+
+    expect(result.workerId).toEqual(scenario.shiftAssignment.two.workerId)
+    expect(result.shiftId).toEqual(scenario.shiftAssignment.two.shiftId)
+  })
+
+  scenario('updates a shiftAssignment', async (scenario: StandardScenario) => {
+    const original = await shiftAssignment({
+      id: scenario.shiftAssignment.one.id,
+    })
+    const result = await updateShiftAssignment({
+      id: original.id,
+      input: { workerId: scenario.shiftAssignment.two.workerId },
+    })
+
+    expect(result.workerId).toEqual(scenario.shiftAssignment.two.workerId)
+  })
+
+  scenario('deletes a shiftAssignment', async (scenario: StandardScenario) => {
+    const original = await deleteShiftAssignment({
+      id: scenario.shiftAssignment.one.id,
+    })
+    const result = await shiftAssignment({ id: original.id })
+
+    expect(result).toEqual(null)
+  })
+})

--- a/api/src/services/shiftAssignments/shiftAssignments.ts
+++ b/api/src/services/shiftAssignments/shiftAssignments.ts
@@ -1,0 +1,45 @@
+import { db } from 'src/lib/db'
+import type {
+  QueryResolvers,
+  MutationResolvers,
+  ShiftAssignmentResolvers,
+} from 'types/graphql'
+
+export const shiftAssignments: QueryResolvers['shiftAssignments'] = () => {
+  return db.shiftAssignment.findMany()
+}
+
+export const shiftAssignment: QueryResolvers['shiftAssignment'] = ({ id }) => {
+  return db.shiftAssignment.findUnique({
+    where: { id },
+  })
+}
+
+export const createShiftAssignment: MutationResolvers['createShiftAssignment'] =
+  ({ input }) => {
+    return db.shiftAssignment.create({
+      data: input,
+    })
+  }
+
+export const updateShiftAssignment: MutationResolvers['updateShiftAssignment'] =
+  ({ id, input }) => {
+    return db.shiftAssignment.update({
+      data: input,
+      where: { id },
+    })
+  }
+
+export const deleteShiftAssignment: MutationResolvers['deleteShiftAssignment'] =
+  ({ id }) => {
+    return db.shiftAssignment.delete({
+      where: { id },
+    })
+  }
+
+export const ShiftAssignment: ShiftAssignmentResolvers = {
+  worker: (_obj, { root }) =>
+    db.shiftAssignment.findUnique({ where: { id: root.id } }).worker(),
+  shift: (_obj, { root }) =>
+    db.shiftAssignment.findUnique({ where: { id: root.id } }).shift(),
+}

--- a/api/src/services/shifts/shifts.ts
+++ b/api/src/services/shifts/shifts.ts
@@ -40,4 +40,6 @@ export const deleteShift: MutationResolvers['deleteShift'] = ({ id }) => {
 export const Shift: ShiftResolvers = {
   location: (_obj, { root }) =>
     db.shift.findUnique({ where: { id: root.id } }).location(),
+  workers: (_obj, { root }) =>
+    db.shift.findUnique({ where: { id: root.id } }).workers(),
 }

--- a/api/src/services/workers/workers.ts
+++ b/api/src/services/workers/workers.ts
@@ -40,4 +40,6 @@ export const deleteWorker: MutationResolvers['deleteWorker'] = ({ id }) => {
 export const Worker: WorkerResolvers = {
   address: (_obj, { root }) =>
     db.worker.findUnique({ where: { id: root.id } }).address(),
+  shifts: (_obj, { root }) =>
+    db.worker.findUnique({ where: { id: root.id } }).shifts(),
 }

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -9,6 +9,7 @@ export default async () => {
     //
     // Update "const data = []" to match your data model and seeding needs
     //
+
     const workSiteData: Prisma.WorksiteCreateArgs['data'][] = [
       { name: 'Dunder Mifflin' },
     ]
@@ -19,6 +20,7 @@ export default async () => {
         return record
       })
     )
+
     const locationData: Prisma.LocationCreateArgs['data'][] = [
       { name: 'Office', worksiteId: workSites[0].id },
       { name: 'Warehouse', worksiteId: workSites[0].id },
@@ -30,6 +32,7 @@ export default async () => {
         return record
       })
     )
+
     const shiftData: Prisma.ShiftCreateArgs['data'][] = [
       { name: 'Day', locationId: locations[1].id },
       { name: 'Night', locationId: locations[1].id },
@@ -42,17 +45,35 @@ export default async () => {
         return record
       })
     )
+
     const workerData: Prisma.WorkerCreateArgs['data'][] = [
       // To try this example data with the UserExample model in schema.prisma,
       // uncomment the lines below and run 'yarn rw prisma migrate dev'
       //
-      { firstName: 'alice', lastName: 'johnson', shiftId: shifts[0].id },
-      { firstName: 'mark', lastName: 'example', shiftId: shifts[1].id },
-      { firstName: 'jackie', lastName: 'jackson', shiftId: shifts[1].id },
-      { firstName: 'bob', lastName: 'bobson', shiftId: shifts[2].id },
+      { firstName: 'alice', lastName: 'johnson' },
+      { firstName: 'mark', lastName: 'example' },
+      { firstName: 'jackie', lastName: 'jackson' },
+      { firstName: 'bob', lastName: 'bobson' },
     ]
-    console.log(
-      "\nUsing the default './scripts/seed.{js,ts}' template\nEdit the file to add seed data\n"
+    const workers = await Promise.all(
+      workerData.map(async (data: Prisma.WorkerCreateArgs['data']) => {
+        const record = await db.worker.create({ data })
+        console.log(record)
+        return record
+      })
+    )
+
+    const shiftAssignmentData: Prisma.ShiftAssignmentCreateArgs['data'][] = [
+      { workerId: workers[0].id, shiftId: shifts[0].id },
+      { workerId: workers[1].id, shiftId: shifts[1].id },
+      { workerId: workers[2].id, shiftId: shifts[2].id },
+    ]
+    await Promise.all(
+      shiftAssignmentData.map(async (data: Prisma.ShiftAssignmentCreateArgs['data']) => {
+        const record = await db.shiftAssignment.create({ data })
+        console.log(record)
+        return record
+      })
     )
 
     // Note: if using PostgreSQL, using `createMany` to insert multiple records is much faster
@@ -61,10 +82,6 @@ export default async () => {
     //
     // Change to match your data model and seeding needs
     //
-    workerData.map(async (data: Prisma.WorkerCreateArgs['data']) => {
-      const record = await db.worker.create({ data })
-      console.log(record)
-    })
     // )
   } catch (error) {
     console.warn('Please define your seed data.')

--- a/web/src/Routes.tsx
+++ b/web/src/Routes.tsx
@@ -8,6 +8,7 @@
 // 'src/pages/Admin/BooksPage/BooksPage.js' -> AdminBooksPage
 
 import { Set, Router, Route } from '@redwoodjs/router'
+import ShiftAssignmentsLayout from 'src/layouts/ShiftAssignmentsLayout'
 import ShiftsLayout from 'src/layouts/ShiftsLayout'
 import LocationsLayout from 'src/layouts/LocationsLayout'
 import WorksitesLayout from 'src/layouts/WorksitesLayout'
@@ -50,6 +51,12 @@ const Routes = () => {
           <Route path="/workers/{id:Int}/edit" page={WorkerEditWorkerPage} name="editWorker" />
           <Route path="/workers/{id:Int}" page={WorkerWorkerPage} name="worker" />
           <Route path="/workers" page={WorkerWorkersPage} name="workers" />
+        </Set>
+        <Set wrap={ShiftAssignmentsLayout}>
+          <Route path="/shift-assignments/new" page={ShiftAssignmentNewShiftAssignmentPage} name="newShiftAssignment" />
+          <Route path="/shift-assignments/{id:Int}/edit" page={ShiftAssignmentEditShiftAssignmentPage} name="editShiftAssignment" />
+          <Route path="/shift-assignments/{id:Int}" page={ShiftAssignmentShiftAssignmentPage} name="shiftAssignment" />
+          <Route path="/shift-assignments" page={ShiftAssignmentShiftAssignmentsPage} name="shiftAssignments" />
         </Set>
         <Route notfound page={NotFoundPage} />
       </Set>

--- a/web/src/components/ShiftAssignment/EditShiftAssignmentCell/EditShiftAssignmentCell.tsx
+++ b/web/src/components/ShiftAssignment/EditShiftAssignmentCell/EditShiftAssignmentCell.tsx
@@ -1,0 +1,61 @@
+import type { EditShiftAssignmentById } from 'types/graphql'
+
+import type { CellSuccessProps, CellFailureProps } from '@redwoodjs/web'
+import { useMutation } from '@redwoodjs/web'
+import { toast } from '@redwoodjs/web/toast'
+import { navigate, routes } from '@redwoodjs/router'
+
+import ShiftAssignmentForm from 'src/components/ShiftAssignment/ShiftAssignmentForm'
+
+export const QUERY = gql`
+  query EditShiftAssignmentById($id: Int!) {
+    shiftAssignment: shiftAssignment(id: $id) {
+      id
+      workerId
+      shiftId
+    }
+  }
+`
+const UPDATE_SHIFT_ASSIGNMENT_MUTATION = gql`
+  mutation UpdateShiftAssignmentMutation($id: Int!, $input: UpdateShiftAssignmentInput!) {
+    updateShiftAssignment(id: $id, input: $input) {
+      id
+      workerId
+      shiftId
+    }
+  }
+`
+
+export const Loading = () => <div>Loading...</div>
+
+export const Failure = ({ error }: CellFailureProps) => (
+  <div className="rw-cell-error">{error.message}</div>
+)
+
+export const Success = ({ shiftAssignment }: CellSuccessProps<EditShiftAssignmentById>) => {
+  const [updateShiftAssignment, { loading, error }] = useMutation(UPDATE_SHIFT_ASSIGNMENT_MUTATION, {
+    onCompleted: () => {
+      toast.success('ShiftAssignment updated')
+      navigate(routes.shiftAssignments())
+    },
+    onError: (error) => {
+      toast.error(error.message)
+    },
+  })
+
+  const onSave = (input, id) => {
+    const castInput = Object.assign(input, { workerId: parseInt(input.workerId), shiftId: parseInt(input.shiftId), })
+    updateShiftAssignment({ variables: { id, input: castInput } })
+  }
+
+  return (
+    <div className="rw-segment">
+      <header className="rw-segment-header">
+        <h2 className="rw-heading rw-heading-secondary">Edit ShiftAssignment {shiftAssignment.id}</h2>
+      </header>
+      <div className="rw-segment-main">
+        <ShiftAssignmentForm shiftAssignment={shiftAssignment} onSave={onSave} error={error} loading={loading} />
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/ShiftAssignment/NewShiftAssignment/NewShiftAssignment.tsx
+++ b/web/src/components/ShiftAssignment/NewShiftAssignment/NewShiftAssignment.tsx
@@ -1,0 +1,42 @@
+import { useMutation } from '@redwoodjs/web'
+import { toast } from '@redwoodjs/web/toast'
+import { navigate, routes } from '@redwoodjs/router'
+import ShiftAssignmentForm from 'src/components/ShiftAssignment/ShiftAssignmentForm'
+
+const CREATE_SHIFT_ASSIGNMENT_MUTATION = gql`
+  mutation CreateShiftAssignmentMutation($input: CreateShiftAssignmentInput!) {
+    createShiftAssignment(input: $input) {
+      id
+    }
+  }
+`
+
+const NewShiftAssignment = () => {
+  const [createShiftAssignment, { loading, error }] = useMutation(CREATE_SHIFT_ASSIGNMENT_MUTATION, {
+    onCompleted: () => {
+      toast.success('ShiftAssignment created')
+      navigate(routes.shiftAssignments())
+    },
+    onError: (error) => {
+      toast.error(error.message)
+    },
+  })
+
+  const onSave = (input) => {
+    const castInput = Object.assign(input, { workerId: parseInt(input.workerId), shiftId: parseInt(input.shiftId), })
+    createShiftAssignment({ variables: { input: castInput } })
+  }
+
+  return (
+    <div className="rw-segment">
+      <header className="rw-segment-header">
+        <h2 className="rw-heading rw-heading-secondary">New ShiftAssignment</h2>
+      </header>
+      <div className="rw-segment-main">
+        <ShiftAssignmentForm onSave={onSave} loading={loading} error={error} />
+      </div>
+    </div>
+  )
+}
+
+export default NewShiftAssignment

--- a/web/src/components/ShiftAssignment/ShiftAssignment/ShiftAssignment.tsx
+++ b/web/src/components/ShiftAssignment/ShiftAssignment/ShiftAssignment.tsx
@@ -1,0 +1,105 @@
+import humanize from 'humanize-string'
+
+import { useMutation } from '@redwoodjs/web'
+import { toast } from '@redwoodjs/web/toast'
+import { Link, routes, navigate } from '@redwoodjs/router'
+
+const DELETE_SHIFT_ASSIGNMENT_MUTATION = gql`
+  mutation DeleteShiftAssignmentMutation($id: Int!) {
+    deleteShiftAssignment(id: $id) {
+      id
+    }
+  }
+`
+
+const formatEnum = (values: string | string[] | null | undefined) => {
+  if (values) {
+    if (Array.isArray(values)) {
+      const humanizedValues = values.map((value) => humanize(value))
+      return humanizedValues.join(', ')
+    } else {
+      return humanize(values as string)
+    }
+  }
+}
+
+const jsonDisplay = (obj) => {
+  return (
+    <pre>
+      <code>{JSON.stringify(obj, null, 2)}</code>
+    </pre>
+  )
+}
+
+const timeTag = (datetime) => {
+  return (
+    datetime && (
+      <time dateTime={datetime} title={datetime}>
+        {new Date(datetime).toUTCString()}
+      </time>
+    )
+  )
+}
+
+const checkboxInputTag = (checked) => {
+  return <input type="checkbox" checked={checked} disabled />
+}
+
+const ShiftAssignment = ({ shiftAssignment }) => {
+  const [deleteShiftAssignment] = useMutation(DELETE_SHIFT_ASSIGNMENT_MUTATION, {
+    onCompleted: () => {
+      toast.success('ShiftAssignment deleted')
+      navigate(routes.shiftAssignments())
+    },
+    onError: (error) => {
+      toast.error(error.message)
+    },
+  })
+
+  const onDeleteClick = (id) => {
+    if (confirm('Are you sure you want to delete shiftAssignment ' + id + '?')) {
+      deleteShiftAssignment({ variables: { id } })
+    }
+  }
+
+  return (
+    <>
+      <div className="rw-segment">
+        <header className="rw-segment-header">
+          <h2 className="rw-heading rw-heading-secondary">ShiftAssignment {shiftAssignment.id} Detail</h2>
+        </header>
+        <table className="rw-table">
+          <tbody>
+            <tr>
+              <th>Id</th>
+              <td>{shiftAssignment.id}</td>
+            </tr><tr>
+              <th>Worker id</th>
+              <td>{shiftAssignment.workerId}</td>
+            </tr><tr>
+              <th>Shift id</th>
+              <td>{shiftAssignment.shiftId}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <nav className="rw-button-group">
+        <Link
+          to={routes.editShiftAssignment({ id: shiftAssignment.id })}
+          className="rw-button rw-button-blue"
+        >
+          Edit
+        </Link>
+        <button
+          type="button"
+          className="rw-button rw-button-red"
+          onClick={() => onDeleteClick(shiftAssignment.id)}
+        >
+          Delete
+        </button>
+      </nav>
+    </>
+  )
+}
+
+export default ShiftAssignment

--- a/web/src/components/ShiftAssignment/ShiftAssignmentCell/ShiftAssignmentCell.tsx
+++ b/web/src/components/ShiftAssignment/ShiftAssignmentCell/ShiftAssignmentCell.tsx
@@ -1,0 +1,26 @@
+import type { FindShiftAssignmentById } from 'types/graphql'
+import type { CellSuccessProps, CellFailureProps } from '@redwoodjs/web'
+
+import ShiftAssignment from 'src/components/ShiftAssignment/ShiftAssignment'
+
+export const QUERY = gql`
+  query FindShiftAssignmentById($id: Int!) {
+    shiftAssignment: shiftAssignment(id: $id) {
+      id
+      workerId
+      shiftId
+    }
+  }
+`
+
+export const Loading = () => <div>Loading...</div>
+
+export const Empty = () => <div>ShiftAssignment not found</div>
+
+export const Failure = ({ error }: CellFailureProps) => (
+  <div className="rw-cell-error">{error.message}</div>
+)
+
+export const Success = ({ shiftAssignment }: CellSuccessProps<FindShiftAssignmentById>) => {
+  return <ShiftAssignment shiftAssignment={shiftAssignment} />
+}

--- a/web/src/components/ShiftAssignment/ShiftAssignmentForm/ShiftAssignmentForm.tsx
+++ b/web/src/components/ShiftAssignment/ShiftAssignmentForm/ShiftAssignmentForm.tsx
@@ -1,0 +1,86 @@
+import {
+  Form,
+  FormError,
+  FieldError,
+  Label,
+  NumberField,
+  Submit,
+} from '@redwoodjs/forms'
+
+
+
+const ShiftAssignmentForm = (props) => {
+  const onSubmit = (data) => {
+
+  
+    
+    
+  
+    
+    
+  
+    props.onSave(data, props?.shiftAssignment?.id)
+  }
+
+  return (
+    <div className="rw-form-wrapper">
+      <Form onSubmit={onSubmit} error={props.error}>
+        <FormError
+          error={props.error}
+          wrapperClassName="rw-form-error-wrapper"
+          titleClassName="rw-form-error-title"
+          listClassName="rw-form-error-list"
+        />
+      
+        <Label
+          name="workerId"
+          className="rw-label"
+          errorClassName="rw-label rw-label-error"
+        >
+          Worker id
+        </Label>
+        
+          <NumberField
+            name="workerId"
+            defaultValue={props.shiftAssignment?.workerId}
+            className="rw-input"
+            errorClassName="rw-input rw-input-error"
+            validation={{ required: true }}
+          />
+        
+
+        <FieldError name="workerId" className="rw-field-error" />
+
+        <Label
+          name="shiftId"
+          className="rw-label"
+          errorClassName="rw-label rw-label-error"
+        >
+          Shift id
+        </Label>
+        
+          <NumberField
+            name="shiftId"
+            defaultValue={props.shiftAssignment?.shiftId}
+            className="rw-input"
+            errorClassName="rw-input rw-input-error"
+            validation={{ required: true }}
+          />
+        
+
+        <FieldError name="shiftId" className="rw-field-error" />
+
+        <div className="rw-button-group">
+          <Submit
+            disabled={props.loading}
+            className="rw-button rw-button-blue"
+          >
+            Save
+          </Submit>
+        </div>
+      </Form>
+    </div>
+  )
+}
+
+export default ShiftAssignmentForm

--- a/web/src/components/ShiftAssignment/ShiftAssignments/ShiftAssignments.tsx
+++ b/web/src/components/ShiftAssignment/ShiftAssignments/ShiftAssignments.tsx
@@ -1,0 +1,128 @@
+import humanize from 'humanize-string'
+
+import { useMutation } from '@redwoodjs/web'
+import { toast } from '@redwoodjs/web/toast'
+import { Link, routes } from '@redwoodjs/router'
+
+import { QUERY } from 'src/components/ShiftAssignment/ShiftAssignmentsCell'
+
+const DELETE_SHIFT_ASSIGNMENT_MUTATION = gql`
+  mutation DeleteShiftAssignmentMutation($id: Int!) {
+    deleteShiftAssignment(id: $id) {
+      id
+    }
+  }
+`
+
+const MAX_STRING_LENGTH = 150
+
+const formatEnum = (values: string | string[] | null | undefined) => {
+  if (values) {
+    if (Array.isArray(values)) {
+      const humanizedValues = values.map((value) => humanize(value))
+      return humanizedValues.join(', ')
+    } else {
+      return humanize(values as string)
+    }
+  }
+}
+
+const truncate = (text) => {
+  let output = text
+  if (text && text.length > MAX_STRING_LENGTH) {
+    output = output.substring(0, MAX_STRING_LENGTH) + '...'
+  }
+  return output
+}
+
+const jsonTruncate = (obj) => {
+  return truncate(JSON.stringify(obj, null, 2))
+}
+
+const timeTag = (datetime) => {
+  return (
+    datetime && (
+      <time dateTime={datetime} title={datetime}>
+        {new Date(datetime).toUTCString()}
+      </time>
+    )
+  )
+}
+
+const checkboxInputTag = (checked) => {
+  return <input type="checkbox" checked={checked} disabled />
+}
+
+const ShiftAssignmentsList = ({ shiftAssignments }) => {
+  const [deleteShiftAssignment] = useMutation(DELETE_SHIFT_ASSIGNMENT_MUTATION, {
+    onCompleted: () => {
+      toast.success('ShiftAssignment deleted')
+    },
+    onError: (error) => {
+      toast.error(error.message)
+    },
+    // This refetches the query on the list page. Read more about other ways to
+    // update the cache over here:
+    // https://www.apollographql.com/docs/react/data/mutations/#making-all-other-cache-updates
+    refetchQueries: [{ query: QUERY }],
+    awaitRefetchQueries: true,
+  })
+
+  const onDeleteClick = (id) => {
+    if (confirm('Are you sure you want to delete shiftAssignment ' + id + '?')) {
+      deleteShiftAssignment({ variables: { id } })
+    }
+  }
+
+  return (
+    <div className="rw-segment rw-table-wrapper-responsive">
+      <table className="rw-table">
+        <thead>
+          <tr>
+            <th>Id</th>
+            <th>Worker id</th>
+            <th>Shift id</th>
+            <th>&nbsp;</th>
+          </tr>
+        </thead>
+        <tbody>
+          {shiftAssignments.map((shiftAssignment) => (
+            <tr key={shiftAssignment.id}>
+              <td>{truncate(shiftAssignment.id)}</td>
+              <td>{truncate(shiftAssignment.workerId)}</td>
+              <td>{truncate(shiftAssignment.shiftId)}</td>
+              <td>
+                <nav className="rw-table-actions">
+                  <Link
+                    to={routes.shiftAssignment({ id: shiftAssignment.id })}
+                    title={'Show shiftAssignment ' + shiftAssignment.id + ' detail'}
+                    className="rw-button rw-button-small"
+                  >
+                    Show
+                  </Link>
+                  <Link
+                    to={routes.editShiftAssignment({ id: shiftAssignment.id })}
+                    title={'Edit shiftAssignment ' + shiftAssignment.id}
+                    className="rw-button rw-button-small rw-button-blue"
+                  >
+                    Edit
+                  </Link>
+                  <button
+                    type="button"
+                    title={'Delete shiftAssignment ' + shiftAssignment.id}
+                    className="rw-button rw-button-small rw-button-red"
+                    onClick={() => onDeleteClick(shiftAssignment.id)}
+                  >
+                    Delete
+                  </button>
+                </nav>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+export default ShiftAssignmentsList

--- a/web/src/components/ShiftAssignment/ShiftAssignmentsCell/ShiftAssignmentsCell.tsx
+++ b/web/src/components/ShiftAssignment/ShiftAssignmentsCell/ShiftAssignmentsCell.tsx
@@ -1,0 +1,40 @@
+import type { FindShiftAssignments } from 'types/graphql'
+import type { CellSuccessProps, CellFailureProps } from '@redwoodjs/web'
+
+import { Link, routes } from '@redwoodjs/router'
+
+import ShiftAssignments from 'src/components/ShiftAssignment/ShiftAssignments'
+
+export const QUERY = gql`
+  query FindShiftAssignments {
+    shiftAssignments {
+      id
+      workerId
+      shiftId
+    }
+  }
+`
+
+export const Loading = () => <div>Loading...</div>
+
+export const Empty = () => {
+  return (
+    <div className="rw-text-center">
+      {'No shiftAssignments yet. '}
+      <Link
+        to={routes.newShiftAssignment()}
+        className="rw-link"
+      >
+        {'Create one?'}
+      </Link>
+    </div>
+  )
+}
+
+export const Failure = ({ error }: CellFailureProps) => (
+  <div className="rw-cell-error">{error.message}</div>
+)
+
+export const Success = ({ shiftAssignments }: CellSuccessProps<FindShiftAssignments>) => {
+  return <ShiftAssignments shiftAssignments={shiftAssignments} />
+}

--- a/web/src/layouts/AdminLayout/AdminLayout.tsx
+++ b/web/src/layouts/AdminLayout/AdminLayout.tsx
@@ -23,6 +23,9 @@ const AdminLayout = ({ children }: AdminLayoutProps) => {
             <li>
               <Link to={routes.newWorksite()}>Add a Worksite</Link>
             </li>
+            <li>
+              <Link to={routes.newShiftAssignment()}>Add a Shift Assignment</Link>
+            </li>
           </ul>
         </nav>
       </header>

--- a/web/src/layouts/ShiftAssignmentsLayout/ShiftAssignmentsLayout.tsx
+++ b/web/src/layouts/ShiftAssignmentsLayout/ShiftAssignmentsLayout.tsx
@@ -1,0 +1,33 @@
+import { Link, routes } from '@redwoodjs/router'
+import { Toaster } from '@redwoodjs/web/toast'
+
+type ShiftAssignmentLayoutProps = {
+  children: React.ReactNode
+}
+
+const ShiftAssignmentsLayout = ({ children }: ShiftAssignmentLayoutProps) => {
+  return (
+    <div className="rw-scaffold">
+      <Toaster toastOptions={{ className: 'rw-toast', duration: 6000 }} />
+      <header className="rw-header">
+        <h1 className="rw-heading rw-heading-primary">
+          <Link
+            to={routes.shiftAssignments()}
+            className="rw-link"
+          >
+            ShiftAssignments
+          </Link>
+        </h1>
+        <Link
+          to={routes.newShiftAssignment()}
+          className="rw-button rw-button-green"
+        >
+          <div className="rw-button-icon">+</div> New ShiftAssignment
+        </Link>
+      </header>
+      <main className="rw-main">{children}</main>
+    </div>
+  )
+}
+
+export default ShiftAssignmentsLayout

--- a/web/src/pages/ShiftAssignment/EditShiftAssignmentPage/EditShiftAssignmentPage.tsx
+++ b/web/src/pages/ShiftAssignment/EditShiftAssignmentPage/EditShiftAssignmentPage.tsx
@@ -1,0 +1,11 @@
+import EditShiftAssignmentCell from 'src/components/ShiftAssignment/EditShiftAssignmentCell'
+
+type ShiftAssignmentPageProps = {
+  id: number
+}
+
+const EditShiftAssignmentPage = ({ id }: ShiftAssignmentPageProps) => {
+  return <EditShiftAssignmentCell id={id} />
+}
+
+export default EditShiftAssignmentPage

--- a/web/src/pages/ShiftAssignment/NewShiftAssignmentPage/NewShiftAssignmentPage.tsx
+++ b/web/src/pages/ShiftAssignment/NewShiftAssignmentPage/NewShiftAssignmentPage.tsx
@@ -1,0 +1,7 @@
+import NewShiftAssignment from 'src/components/ShiftAssignment/NewShiftAssignment'
+
+const NewShiftAssignmentPage = () => {
+  return <NewShiftAssignment />
+}
+
+export default NewShiftAssignmentPage

--- a/web/src/pages/ShiftAssignment/ShiftAssignmentPage/ShiftAssignmentPage.tsx
+++ b/web/src/pages/ShiftAssignment/ShiftAssignmentPage/ShiftAssignmentPage.tsx
@@ -1,0 +1,11 @@
+import ShiftAssignmentCell from 'src/components/ShiftAssignment/ShiftAssignmentCell'
+
+type ShiftAssignmentPageProps = {
+  id: number
+}
+
+const ShiftAssignmentPage = ({ id }: ShiftAssignmentPageProps) => {
+  return <ShiftAssignmentCell id={id} />
+}
+
+export default ShiftAssignmentPage

--- a/web/src/pages/ShiftAssignment/ShiftAssignmentsPage/ShiftAssignmentsPage.tsx
+++ b/web/src/pages/ShiftAssignment/ShiftAssignmentsPage/ShiftAssignmentsPage.tsx
@@ -1,0 +1,7 @@
+import ShiftAssignmentsCell from 'src/components/ShiftAssignment/ShiftAssignmentsCell'
+
+const ShiftAssignmentsPage = () => {
+  return <ShiftAssignmentsCell />
+}
+
+export default ShiftAssignmentsPage


### PR DESCRIPTION
This is broken up by commits to make it easier to see what changed.  Instead of workers having a shift, we're using a many-to-many model where workers and shifts are joined by the new `ShiftAssignment` table.  It's based on the redwood docs here: https://redwoodjs.com/docs/schema-relations#supported-table-structure for further reading.

![image](https://user-images.githubusercontent.com/1423526/173472333-d0afa3aa-75d6-4919-8b89-d32d944b0840.png)

Also interesting to ponder these query results.  Depending on whether we find it annoying or not, we could change the model to workers having a single shift